### PR TITLE
Adicionando endpoint para encerrar um evento

### DIFF
--- a/backend/src/main/java/com/techfun/altrua/core/common/exceptions/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/techfun/altrua/core/common/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,21 @@
+package com.techfun.altrua.core.common.exceptions;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exceção lançada quando um recurso solicitado não é encontrado no sistema.
+ *
+ * <p>
+ * Retorna o status {@link HttpStatus#NOT_FOUND} (404).
+ * </p>
+ */
+public class ResourceNotFoundException extends BusinessException {
+    /**
+     * Constrói a exceção com o nome do recurso que não foi encontrado.
+     *
+     * @param resourceName Nome do recurso não encontrado (ex: "Usuário", "Evento").
+     */
+    public ResourceNotFoundException(String resourceName) {
+        super(resourceName + " não encontrado", HttpStatus.NOT_FOUND);
+    }
+}

--- a/backend/src/main/java/com/techfun/altrua/core/common/util/SecurityUtils.java
+++ b/backend/src/main/java/com/techfun/altrua/core/common/util/SecurityUtils.java
@@ -1,0 +1,55 @@
+package com.techfun.altrua.core.common.util;
+
+import java.util.UUID;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.techfun.altrua.infra.security.userdetails.UserPrincipal;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utilitário para acesso centralizado aos dados de segurança do Spring
+ * Security.
+ * <p>
+ * Fornece métodos estáticos para extração de identidade e validação do estado
+ * de autenticação da thread atual.
+ * </p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SecurityUtils {
+
+    /**
+     * Extrai o identificador do usuário autenticado do contexto de segurança.
+     * <p>
+     * Este método exige uma sessão válida e um principal do tipo
+     * {@link UserPrincipal}.
+     * </p>
+     *
+     * @return {@link UUID} do usuário logado.
+     * @throws InsufficientAuthenticationException se não houver usuário
+     *                                             autenticado;
+     *                                             {@link AuthenticationServiceException}
+     *                                             se o principal for inválido.
+     */
+    public static UUID getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null ||
+                !authentication.isAuthenticated() ||
+                authentication instanceof AnonymousAuthenticationToken) {
+            throw new InsufficientAuthenticationException("Sessão expirada ou usuário não autenticado");
+        }
+
+        if (authentication.getPrincipal() instanceof UserPrincipal userPrincipal) {
+            return userPrincipal.getUser().getId();
+        }
+
+        throw new AuthenticationServiceException("O objeto Principal no SecurityContext não é do tipo UserPrincipal");
+    }
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,7 +15,6 @@ import com.techfun.altrua.features.event.api.dto.EventResponseDTO;
 import com.techfun.altrua.features.event.api.dto.RegisterEventRequestDTO;
 import com.techfun.altrua.features.event.domain.model.Event;
 import com.techfun.altrua.features.event.service.EventService;
-import com.techfun.altrua.infra.security.userdetails.UserPrincipal;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,34 +29,47 @@ import lombok.RequiredArgsConstructor;
  * </p>
  */
 @RestController
-@RequestMapping("/ongs/{ongId}/events")
+@RequestMapping("/ongs/{ongId}/eventos")
 @RequiredArgsConstructor
 public class EventController {
 
     private final EventService eventService;
 
     /**
-     * Registra um novo evento para uma ONG específica.
-     * 
+     * Registra um novo evento vinculado a uma ONG.
      * <p>
-     * Este endpoint exige que o usuário esteja autenticado. A permissão de
-     * administrador sobre a ONG informada é validada no nível de serviço.
+     * A autorização é validada via {@code SecurityService}, garantindo que o
+     * usuário
+     * autenticado seja administrador da ONG informada.
      * </p>
      *
-     * @param ongId         O UUID da ONG proprietária do evento.
-     * @param request       Objeto contendo os dados de criação do evento.
-     * @param userPrincipal O usuário autenticado extraído do contexto de segurança.
-     * @return {@link ResponseEntity} contendo o DTO do evento criado e o status 201
-     *         (Created).
-     * 
-     * @see com.techfun.altrua.features.event.service.EventService#register(UUID,
-     *      RegisterEventRequestDTO, com.techfun.altrua.features.user.domain.User)
+     * @param ongId   UUID da ONG proprietária.
+     * @param request Dados para criação do evento.
+     * @return {@link EventResponseDTO} com o status 201 (Created).
      */
     @PostMapping
-    public ResponseEntity<EventResponseDTO> register(@PathVariable UUID ongId,
-            @RequestBody @Valid RegisterEventRequestDTO request, @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        Event savedEvent = eventService.register(ongId, request, userPrincipal.getUser());
+    @PreAuthorize("@securityService.isOngAdmin(#ongId)")
+    public ResponseEntity<EventResponseDTO> register(@PathVariable("ongId") UUID ongId,
+            @RequestBody @Valid RegisterEventRequestDTO request) {
+        Event savedEvent = eventService.register(ongId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(EventResponseDTO.fromEntity(savedEvent));
+    }
+
+    /**
+     * Finaliza um evento específico.
+     * <p>
+     * Verifica se o usuário tem permissão de gerenciamento sobre o evento antes de
+     * delegar a finalização ao serviço de domínio.
+     * </p>
+     *
+     * @param eventId UUID do evento a ser encerrado.
+     * @return Status 204 (No Content).
+     */
+    @PostMapping("/{eventId}/encerrar")
+    @PreAuthorize("@securityService.canManageEvent(#eventId)")
+    public ResponseEntity<Void> endEvent(@PathVariable UUID eventId) {
+        eventService.endEvent(eventId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
@@ -16,6 +16,11 @@ import com.techfun.altrua.features.event.api.dto.RegisterEventRequestDTO;
 import com.techfun.altrua.features.event.domain.model.Event;
 import com.techfun.altrua.features.event.service.EventService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +33,7 @@ import lombok.RequiredArgsConstructor;
  * a organizações específicas, garantindo as regras de autorização necessárias.
  * </p>
  */
+@Tag(name = "Eventos", description = "Gerenciamento de eventos vinculados a ONGs")
 @RestController
 @RequestMapping("/ongs/{ongId}/eventos")
 @RequiredArgsConstructor
@@ -47,9 +53,18 @@ public class EventController {
      * @param request Dados para criação do evento.
      * @return {@link EventResponseDTO} com o status 201 (Created).
      */
+    @Operation(summary = "Registrar novo evento", description = "Cria um evento vinculado a uma ONG. Requer que o usuário seja administrador da ONG informada.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Evento criado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou ausência de tags obrigatórias"),
+            @ApiResponse(responseCode = "403", description = "Usuário não possui permissão de administrador na ONG"),
+            @ApiResponse(responseCode = "404", description = "ONG não encontrada"),
+            @ApiResponse(responseCode = "409", description = "Conflito: Slug do evento já existe")
+    })
     @PostMapping
     @PreAuthorize("@securityService.isOngAdmin(#ongId)")
-    public ResponseEntity<EventResponseDTO> register(@PathVariable("ongId") UUID ongId,
+    public ResponseEntity<EventResponseDTO> register(
+            @Parameter(description = "UUID da ONG proprietária") @PathVariable("ongId") UUID ongId,
             @RequestBody @Valid RegisterEventRequestDTO request) {
         Event savedEvent = eventService.register(ongId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(EventResponseDTO.fromEntity(savedEvent));
@@ -65,9 +80,18 @@ public class EventController {
      * @param eventId UUID do evento a ser encerrado.
      * @return Status 204 (No Content).
      */
+    @Operation(summary = "Encerrar evento", description = "Finaliza um evento ativo. Requer permissão de gerenciamento sobre o evento específico.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Evento encerrado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Regra de negócio violada: o evento não pode ser encerrado no status atual"),
+            @ApiResponse(responseCode = "403", description = "Usuário não tem permissão para gerenciar este evento"),
+            @ApiResponse(responseCode = "404", description = "Evento não encontrado")
+    })
     @PostMapping("/{eventId}/encerrar")
     @PreAuthorize("@securityService.canManageEvent(#eventId)")
-    public ResponseEntity<Void> endEvent(@PathVariable UUID eventId) {
+    public ResponseEntity<Void> endEvent(
+            @Parameter(description = "UUID da ONG proprietária") @PathVariable("ongId") UUID ongId,
+            @Parameter(description = "UUID do evento a ser encerrado") @PathVariable UUID eventId) {
         eventService.endEvent(eventId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
@@ -73,12 +73,15 @@ public class EventController {
     /**
      * Finaliza um evento específico.
      * <p>
-     * Verifica se o usuário tem permissão de gerenciamento sobre o evento antes de
-     * delegar a finalização ao serviço de domínio.
+     * O acesso é restrito a administradores da ONG proprietária. A validação de
+     * permissão
+     * e a integridade da relação entre ONG e Evento são realizadas na camada de
+     * segurança.
      * </p>
      *
+     * @param ongId   UUID da ONG proprietária para validação de integridade.
      * @param eventId UUID do evento a ser encerrado.
-     * @return Status 204 (No Content).
+     * @return Status 204 (No Content) em caso de sucesso.
      */
     @Operation(summary = "Encerrar evento", description = "Finaliza um evento ativo. Requer permissão de gerenciamento sobre o evento específico.")
     @ApiResponses({
@@ -88,11 +91,11 @@ public class EventController {
             @ApiResponse(responseCode = "404", description = "Evento não encontrado ou não pertence a esta ONG")
     })
     @PostMapping("/{eventId}/encerrar")
-    @PreAuthorize("@securityService.canManageEvent(#eventId)")
+    @PreAuthorize("@securityService.canManageEvent(#ongId, #eventId)")
     public ResponseEntity<Void> endEvent(
             @Parameter(description = "UUID da ONG proprietária") @PathVariable("ongId") UUID ongId,
-            @Parameter(description = "UUID do evento a ser encerrado") @PathVariable UUID eventId) {
-        eventService.endEvent(ongId, eventId);
+            @Parameter(description = "UUID do evento a ser encerrado") @PathVariable("eventId") UUID eventId) {
+        eventService.endEvent(eventId);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
@@ -85,14 +85,14 @@ public class EventController {
             @ApiResponse(responseCode = "204", description = "Evento encerrado com sucesso"),
             @ApiResponse(responseCode = "400", description = "Regra de negócio violada: o evento não pode ser encerrado no status atual"),
             @ApiResponse(responseCode = "403", description = "Usuário não tem permissão para gerenciar este evento"),
-            @ApiResponse(responseCode = "404", description = "Evento não encontrado")
+            @ApiResponse(responseCode = "404", description = "Evento não encontrado ou não pertence a esta ONG")
     })
     @PostMapping("/{eventId}/encerrar")
     @PreAuthorize("@securityService.canManageEvent(#eventId)")
     public ResponseEntity<Void> endEvent(
             @Parameter(description = "UUID da ONG proprietária") @PathVariable("ongId") UUID ongId,
             @Parameter(description = "UUID do evento a ser encerrado") @PathVariable UUID eventId) {
-        eventService.endEvent(eventId);
+        eventService.endEvent(ongId, eventId);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/dto/EventResponseDTO.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/dto/EventResponseDTO.java
@@ -9,6 +9,8 @@ import java.util.stream.Collectors;
 import com.techfun.altrua.features.event.domain.model.Event;
 import com.techfun.altrua.features.event.domain.model.Tag;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Objeto de Transferência de Dados (DTO) para representação de eventos.
  * 
@@ -40,23 +42,40 @@ import com.techfun.altrua.features.event.domain.model.Tag;
  * 
  * @see com.techfun.altrua.features.event.domain.model.Event
  */
+@Schema(description = "Objeto de resposta com os detalhes completos de um evento")
 public record EventResponseDTO(
-        UUID id,
-        String title,
-        String description,
-        String slug,
-        String coverUrl,
-        String externalLink,
-        String donationInfo,
-        String donationExternalLink,
-        boolean acceptsVolunteers,
-        Integer maxVolunteers,
-        BigDecimal latitude,
-        BigDecimal longitude,
-        String addressLabel,
-        Instant startsAt,
-        Instant endsAt,
-        Set<String> tags) {
+
+        @Schema(description = "Identificador único do evento", example = "550e8400-e29b-411d-a716-446655440000") UUID id,
+
+        @Schema(description = "Título descritivo do evento", example = "Mutirão de Reflorestamento Urbano") String title,
+
+        @Schema(description = "Texto detalhado sobre o que ocorrerá no evento", example = "Evento destinado ao plantio de mudas nativas no parque central.") String description,
+
+        @Schema(description = "Identificador amigável para URLs", example = "mutirao-reflorestamento-2026") String slug,
+
+        @Schema(description = "URL da imagem de capa/banner", example = "https://cdn.ong.org/images/evento-01.jpg") String coverUrl,
+
+        @Schema(description = "Link externo para mais informações", example = "https://ong.org/evento-detalhes") String externalLink,
+
+        @Schema(description = "Informações sobre como apoiar financeiramente", example = "Aceitamos doações via PIX ou cartão.") String donationInfo,
+
+        @Schema(description = "Link direto para plataforma de doação externa", example = "https://apoia.se/projeto-ong") String donationExternalLink,
+
+        @Schema(description = "Indica se o evento aceita novos voluntários", example = "true") boolean acceptsVolunteers,
+
+        @Schema(description = "Capacidade máxima de voluntários permitida", example = "50", nullable = true) Integer maxVolunteers,
+
+        @Schema(description = "Latitude para geolocalização", example = "-23.550520") BigDecimal latitude,
+
+        @Schema(description = "Longitude para geolocalização", example = "-46.633308") BigDecimal longitude,
+
+        @Schema(description = "Descrição textual do endereço", example = "Rua das Palmeiras, 123, São Paulo - SP") String addressLabel,
+
+        @Schema(description = "Instante de início do evento", example = "2026-05-20T09:00:00Z") Instant startsAt,
+
+        @Schema(description = "Instante de término previsto", example = "2026-05-20T17:00:00Z") Instant endsAt,
+
+        @Schema(description = "Conjunto de categorias vinculadas", example = "[\"meio ambiente\", \"sustentabilidade\"]") Set<String> tags) {
 
     /**
      * Converte uma entidade de domínio {@link Event} para seu respectivo DTO de

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/dto/RegisterEventRequestDTO.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/dto/RegisterEventRequestDTO.java
@@ -9,6 +9,7 @@ import com.techfun.altrua.features.event.domain.model.Event;
 import com.techfun.altrua.features.ong.domain.model.Ong;
 import com.techfun.altrua.features.user.domain.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -46,21 +47,36 @@ import jakarta.validation.constraints.NotNull;
  * @see com.techfun.altrua.features.event.domain.model.Event
  * @see com.techfun.altrua.features.event.domain.enums.EventStatusEnum
  */
+@Schema(description = "Dados necessários para o registro de um novo evento")
 public record RegisterEventRequestDTO(
-        @NotBlank(message = "Title is required") String title,
-        String description,
-        String coverUrl,
-        String externalLink,
-        String donationInfo,
-        String donationExternalLink,
-        @NotNull(message = "Accepts volunteers is required") Boolean acceptsVolunteers,
-        Integer maxVolunteers,
-        BigDecimal latitude,
-        BigDecimal longitude,
-        String addressLabel,
-        @NotNull(message = "Start date and time are required") Instant startsAt,
-        Instant endsAt,
-        @NotEmpty(message = "At least one tag must be provided") Set<@NotBlank(message = "Tag name is required") String> tags) {
+
+        @Schema(description = "Título descritivo do evento", example = "Mutirão de Limpeza de Praia") @NotBlank(message = "O título é obrigatório") String title,
+
+        @Schema(description = "Descrição detalhada sobre as atividades do evento", example = "Coleta de resíduos sólidos na orla da Praia Central.") String description,
+
+        @Schema(description = "URL da imagem de capa ou banner", example = "https://cdn.ong.org/images/banner-evento.jpg") String coverUrl,
+
+        @Schema(description = "Link para site externo ou formulário de inscrição", example = "https://ong.org/info-evento") String externalLink,
+
+        @Schema(description = "Instruções ou informações sobre doações", example = "As doações serão destinadas à compra de sacos de lixo e luvas.") String donationInfo,
+
+        @Schema(description = "Link para plataforma de arrecadação externa", example = "https://doar.ong.org/campanha-limpeza") String donationExternalLink,
+
+        @Schema(description = "Define se o evento está aberto para voluntários", example = "true") @NotNull(message = "A indicação de aceitação de voluntários é obrigatória") Boolean acceptsVolunteers,
+
+        @Schema(description = "Número máximo de voluntários permitidos (caso o evento aceitar voluntários)", example = "100") Integer maxVolunteers,
+
+        @Schema(description = "Coordenada de latitude para o local do evento", example = "-23.550520") BigDecimal latitude,
+
+        @Schema(description = "Coordenada de longitude para o local do evento", example = "-46.633308") BigDecimal longitude,
+
+        @Schema(description = "Endereço por extenso ou nome do local", example = "Avenida Beira Mar, S/N, Centro") String addressLabel,
+
+        @Schema(description = "Data e hora de início do evento (ISO 8601)", example = "2026-06-15T08:00:00Z") @NotNull(message = "A data e hora de início são obrigatórias") Instant startsAt,
+
+        @Schema(description = "Data e hora de término prevista (ISO 8601)", example = "2026-06-15T12:00:00Z") Instant endsAt,
+
+        @Schema(description = "Conjunto de nomes das tags para categorização", example = "[\"Meio Ambiente\", \"Limpeza\"]") @NotEmpty(message = "É obrigatório informar ao menos uma tag") Set<@NotBlank(message = "O nome da tag não pode estar em branco") String> tags) {
 
     /**
      * Mapeia os dados do DTO para uma nova instância da entidade {@link Event}.

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Event.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Event.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import com.techfun.altrua.core.common.exceptions.DomainException;
 import com.techfun.altrua.features.event.domain.enums.EventStatusEnum;
 import com.techfun.altrua.features.ong.domain.model.Ong;
 import com.techfun.altrua.features.user.domain.User;
@@ -165,6 +166,31 @@ public class Event {
      * está ativo.
      */
     private Instant deletedAt;
+
+    /**
+     * Altera o estado do evento para finalizado e define o instante de término.
+     * <p>
+     * Garante a idempotência da operação e impede o encerramento de eventos
+     * previamente cancelados.
+     * </p>
+     * * @throws DomainException se o evento estiver com status
+     * {@link EventStatusEnum#CANCELED}.
+     */
+    public void finish() {
+        if (this.status == EventStatusEnum.CANCELED) {
+            throw new DomainException("Não é possível encerrar um evento que foi cancelado.");
+        }
+
+        if (this.status == EventStatusEnum.FINISHED) {
+            return;
+        }
+
+        if (this.endsAt == null || this.endsAt.isAfter(Instant.now())) {
+            this.endsAt = Instant.now();
+        }
+
+        this.status = EventStatusEnum.FINISHED;
+    }
 
     /**
      * Gancho de ciclo de vida executado antes da persistência inicial.

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
@@ -34,7 +34,7 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     /**
      * Verifica se um usuário possui privilégios administrativos sobre um evento
      * específico.
-     * * @param eventId Identificador do evento.
+     * @param eventId Identificador do evento.
      * 
      * @param userId Identificador do usuário.
      * @return {@code true} se o usuário for administrador da ONG responsável pelo

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
@@ -1,8 +1,11 @@
 package com.techfun.altrua.features.event.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.techfun.altrua.features.event.domain.model.Event;
 
@@ -32,13 +35,19 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
     public boolean existsBySlug(String slug);
 
     /**
-     * Verifica se um usuário possui privilégios administrativos sobre um evento
-     * específico.
+     * Recupera o evento com carregamento antecipado (Eager Loading) da ONG e seus
+     * administradores.
+     * <p>
+     * Utiliza {@code JOIN FETCH} para evitar o problema de N+1 e garantir que as
+     * associações
+     * estejam disponíveis mesmo fora da transação original, prevenindo
+     * {@code LazyInitializationException}.
+     * </p>
+     *
      * @param eventId Identificador do evento.
-     * 
-     * @param userId Identificador do usuário.
-     * @return {@code true} se o usuário for administrador da ONG responsável pelo
-     *         evento.
+     * @return {@link Optional} com o evento e associações carregadas, ou vazio se
+     *         não encontrado.
      */
-    public boolean existsByIdAndOng_Administrators_User_Id(UUID eventId, UUID userId);
+    @Query("SELECT e FROM Event e JOIN FETCH e.ong o LEFT JOIN FETCH o.administrators a WHERE e.id = :eventId")
+    Optional<Event> findByIdWithOngAndAdmins(@Param("eventId") UUID eventId);
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
@@ -30,4 +30,15 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
      *         contrário.
      */
     public boolean existsBySlug(String slug);
+
+    /**
+     * Verifica se um usuário possui privilégios administrativos sobre um evento
+     * específico.
+     * * @param eventId Identificador do evento.
+     * 
+     * @param userId Identificador do usuário.
+     * @return {@code true} se o usuário for administrador da ONG responsável pelo
+     *         evento.
+     */
+    public boolean existsByIdAndOng_Administrators_User_Id(UUID eventId, UUID userId);
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
@@ -105,13 +105,9 @@ public class EventService {
      *                                   não permitir o encerramento.
      */
     @Transactional
-    public void endEvent(UUID ongId, UUID eventId) {
+    public void endEvent(UUID eventId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new ResourceNotFoundException("Evento"));
-
-        if (!event.getOng().getId().equals(ongId)) {
-            throw new ResourceNotFoundException("Evento");
-        }
 
         event.finish();
         eventRepository.save(event);

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.techfun.altrua.core.common.exceptions.DomainException;
 import com.techfun.altrua.core.common.exceptions.DuplicateResourceException;
-import com.techfun.altrua.core.common.exceptions.ForbiddenActionException;
 import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
 import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.core.common.util.SlugUtils;
@@ -47,20 +46,20 @@ public class EventService {
     private final TagService tagService;
 
     /**
-     * Registra um novo evento associado a uma ONG e ao seu criador.
-     *
+     * Registra um novo evento associado a uma ONG.
      * <p>
-     * O fluxo compreende a validação de permissões administrativas, a normalização
-     * e
-     * persistência idempotente de etiquetas (tags) e a geração de um identificador
-     * amigável (slug) para a URL do evento.
+     * O método realiza a normalização e persistência de etiquetas (tags), gera um
+     * slug
+     * único para a URL e persiste a entidade. A validação de permissões
+     * administrativas
+     * é delegada à camada de segurança via {@code @PreAuthorize}.
      * </p>
      *
-     * @param ongId   UUID da organização proprietária do evento.
-     * @param request DTO com os dados de entrada validados.
-     * @throws ForbiddenActionException   Se o criador não for administrador da ONG.
-     * @throws DuplicateResourceException Se o slug gerado colidir com um evento
-     *                                    ativo.
+     * @param ongId   UUID da organização proprietária.
+     * @param request DTO com os dados do evento.
+     * @return O evento registrado e persistido.
+     * @throws DuplicateResourceException Se houver colisão de slug que não pôde ser
+     *                                    resolvida.
      */
     @Transactional
     public Event register(UUID ongId, RegisterEventRequestDTO request) {

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
@@ -8,8 +8,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.techfun.altrua.core.common.exceptions.DomainException;
 import com.techfun.altrua.core.common.exceptions.DuplicateResourceException;
 import com.techfun.altrua.core.common.exceptions.ForbiddenActionException;
+import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.core.common.util.SlugUtils;
 import com.techfun.altrua.features.event.api.dto.RegisterEventRequestDTO;
 import com.techfun.altrua.features.event.domain.model.Event;
@@ -17,8 +19,8 @@ import com.techfun.altrua.features.event.domain.model.Tag;
 import com.techfun.altrua.features.event.repository.EventRepository;
 import com.techfun.altrua.features.ong.domain.model.Ong;
 import com.techfun.altrua.features.ong.repository.OngRepository;
-import com.techfun.altrua.features.ong.service.OngService;
 import com.techfun.altrua.features.user.domain.User;
+import com.techfun.altrua.features.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,9 +40,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class EventService {
 
+    private final UserRepository userRepository;
     private final EventRepository eventRepository;
     private final OngRepository ongRepository;
-    private final OngService ongService;
     private final TagService tagService;
 
     /**
@@ -55,15 +57,15 @@ public class EventService {
      *
      * @param ongId   UUID da organização proprietária do evento.
      * @param request DTO com os dados de entrada validados.
-     * @param creator Entidade do usuário autenticado que realiza a operação.
-     * @return O {@link Event} persistido e associado.
      * @throws ForbiddenActionException   Se o criador não for administrador da ONG.
      * @throws DuplicateResourceException Se o slug gerado colidir com um evento
      *                                    ativo.
      */
     @Transactional
-    public Event register(UUID ongId, RegisterEventRequestDTO request, User creator) {
-        ongService.validateAdminPermission(ongId, creator.getId());
+    public Event register(UUID ongId, RegisterEventRequestDTO request) {
+        UUID currentUserId = SecurityUtils.getCurrentUserId();
+        User creator = userRepository.getReferenceById(currentUserId);
+
         Ong ong = ongRepository.getReferenceById(ongId);
         Set<Tag> managedTags = tagService.getOrCreateTags(request.tags());
 
@@ -87,5 +89,26 @@ public class EventService {
             log.error("Erro técnico inesperado ao cadastrar evento: {}", ex.getMessage());
             throw ex;
         }
+    }
+
+    /**
+     * Encerra um evento atualizando seu status e data de término.
+     * <p>
+     * Valida as regras de transição de estado na entidade e sincroniza as
+     * alterações no banco de dados.
+     * </p>
+     *
+     * @param eventId Identificador do evento.
+     * @throws DomainException se o ID for inválido;
+     *                         {@link DomainException} se o status atual
+     *                         não permitir o encerramento.
+     */
+    @Transactional
+    public void endEvent(UUID eventId) {
+        Event event = eventRepository.findById(eventId).orElseThrow(() -> new DomainException("Evento não encontrado"));
+
+        event.finish();
+
+        eventRepository.save(event);
     }
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
@@ -105,12 +105,15 @@ public class EventService {
      *                                   não permitir o encerramento.
      */
     @Transactional
-    public void endEvent(UUID eventId) {
+    public void endEvent(UUID ongId, UUID eventId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new ResourceNotFoundException("Evento"));
 
-        event.finish();
+        if (!event.getOng().getId().equals(ongId)) {
+            throw new ResourceNotFoundException("Evento");
+        }
 
+        event.finish();
         eventRepository.save(event);
     }
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.techfun.altrua.core.common.exceptions.DomainException;
 import com.techfun.altrua.core.common.exceptions.DuplicateResourceException;
 import com.techfun.altrua.core.common.exceptions.ForbiddenActionException;
+import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
 import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.core.common.util.SlugUtils;
 import com.techfun.altrua.features.event.api.dto.RegisterEventRequestDTO;
@@ -99,13 +100,14 @@ public class EventService {
      * </p>
      *
      * @param eventId Identificador do evento.
-     * @throws DomainException se o ID for inválido;
-     *                         {@link DomainException} se o status atual
-     *                         não permitir o encerramento.
+     * @throws ResourceNotFoundException se o ID for inválido;
+     *                                   {@link DomainException} se o status atual
+     *                                   não permitir o encerramento.
      */
     @Transactional
     public void endEvent(UUID eventId) {
-        Event event = eventRepository.findById(eventId).orElseThrow(() -> new DomainException("Evento não encontrado"));
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new ResourceNotFoundException("Evento"));
 
         event.finish();
 

--- a/backend/src/main/java/com/techfun/altrua/features/ong/api/OngController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/ong/api/OngController.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +17,6 @@ import com.techfun.altrua.features.ong.api.dto.OngResponseDTO;
 import com.techfun.altrua.features.ong.api.dto.RegisterOngRequestDTO;
 import com.techfun.altrua.features.ong.domain.model.Ong;
 import com.techfun.altrua.features.ong.service.OngService;
-import com.techfun.altrua.infra.security.userdetails.UserPrincipal;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,16 +44,13 @@ public class OngController {
      * automaticamente como o administrador criador da organização.
      * </p>
      *
-     * @param dto           objeto contendo os dados cadastrais da ONG
-     * @param userPrincipal detalhes do usuário autenticado obtidos via Spring
-     *                      Security
+     * @param dto objeto contendo os dados cadastrais da ONG
      * @return {@link ResponseEntity} contendo os dados da ONG criada com status 201
      *         (Created)
      */
     @PostMapping
-    public ResponseEntity<OngResponseDTO> register(@RequestBody @Valid RegisterOngRequestDTO dto,
-            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        Ong savedOng = ongService.register(dto, userPrincipal.getUser());
+    public ResponseEntity<OngResponseDTO> register(@RequestBody @Valid RegisterOngRequestDTO dto) {
+        Ong savedOng = ongService.register(dto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(OngResponseDTO.fromEntity(savedOng));
     }

--- a/backend/src/main/java/com/techfun/altrua/features/ong/api/dto/RegisterOngRequestDTO.java
+++ b/backend/src/main/java/com/techfun/altrua/features/ong/api/dto/RegisterOngRequestDTO.java
@@ -33,7 +33,7 @@ import jakarta.validation.constraints.Pattern;
 public record RegisterOngRequestDTO(
 
         @NotBlank(message = "Name is required") String name,
-        @NotBlank(message = "CNPJ is required") @Pattern(regexp = "\\d{14}", message = "Invalid Format") String cnpj,
+        @Pattern(regexp = "\\d{14}", message = "Invalid Format") String cnpj,
         @NotBlank(message = "Email is required") @Email String email,
         @NotBlank(message = "Category is required") String category,
         String description,

--- a/backend/src/main/java/com/techfun/altrua/features/ong/service/OngService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/ong/service/OngService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.techfun.altrua.core.common.exceptions.DuplicateResourceException;
-import com.techfun.altrua.core.common.exceptions.ForbiddenActionException;
+import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.core.common.util.SlugUtils;
 import com.techfun.altrua.features.ong.api.OngSpecification;
 import com.techfun.altrua.features.ong.api.dto.OngFilterDTO;
@@ -19,10 +19,9 @@ import com.techfun.altrua.features.ong.api.dto.OngResponseDTO;
 import com.techfun.altrua.features.ong.api.dto.RegisterOngRequestDTO;
 import com.techfun.altrua.features.ong.domain.model.Ong;
 import com.techfun.altrua.features.ong.domain.model.OngAdministrator;
-import com.techfun.altrua.features.ong.domain.model.OngAdministratorId;
-import com.techfun.altrua.features.ong.repository.OngAdministratorRepository;
 import com.techfun.altrua.features.ong.repository.OngRepository;
 import com.techfun.altrua.features.user.domain.User;
+import com.techfun.altrua.features.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +42,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OngService {
 
     private final OngRepository ongRepository;
-    private final OngAdministratorRepository ongAdministratorRepository;
+    private final UserRepository userRepository;
 
     /**
      * Registra uma nova organização (ONG) e estabelece seu administrador inicial.
@@ -55,14 +54,15 @@ public class OngService {
      * </p>
      *
      * @param request DTO com os dados de entrada validados.
-     * @param creator Usuário autenticado que será definido como administrador e
-     *                criador.
      * @return A entidade {@link Ong} persistida e configurada.
      * @throws DuplicateResourceException Se o CNPJ ou o Slug gerado já pertencerem
      *                                    a uma ONG ativa.
      */
     @Transactional
-    public Ong register(RegisterOngRequestDTO request, User creator) {
+    public Ong register(RegisterOngRequestDTO request) {
+        UUID currentUserId = SecurityUtils.getCurrentUserId();
+        User creator = userRepository.getReferenceById(currentUserId);
+
         if (request.cnpj() != null && ongRepository.existsByCnpj(request.cnpj())) {
             throw new DuplicateResourceException("CNPJ já cadastrado.");
         }
@@ -117,30 +117,5 @@ public class OngService {
     public Page<OngResponseDTO> listNgos(OngFilterDTO filter, Pageable pageable) {
         Specification<Ong> spec = OngSpecification.withFilter(filter);
         return ongRepository.findAll(spec, pageable).map(OngResponseDTO::fromEntity);
-    }
-
-    /**
-     * Valida se um usuário possui privilégios de administrador para uma ONG
-     * específica.
-     * <p>
-     * Realiza uma consulta de existência na base de dados para verificar o vínculo
-     * de
-     * administração. Caso o vínculo não exista, um log de aviso é gerado para fins
-     * de
-     * auditoria e segurança.
-     * </p>
-     *
-     * @param ongId  O identificador único da ONG alvo da operação.
-     * @param userId O identificador único do usuário que tenta realizar a ação.
-     * @throws ForbiddenActionException Se o usuário não estiver registrado como
-     *                                  administrador da ONG informada.
-     */
-    public void validateAdminPermission(UUID ongId, UUID userId) {
-        OngAdministratorId id = new OngAdministratorId(userId, ongId);
-
-        if (!ongAdministratorRepository.existsById(id)) {
-            log.warn("Tentativa de acesso não autorizado: Usuário {} na ONG {}", userId, ongId);
-            throw new ForbiddenActionException("Você não tem permissão para realizar essa ação.");
-        }
     }
 }

--- a/backend/src/main/java/com/techfun/altrua/features/user/api/UserController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/user/api/UserController.java
@@ -1,7 +1,6 @@
 package com.techfun.altrua.features.user.api;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,7 +8,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.techfun.altrua.features.user.api.dto.UserResponseDTO;
 import com.techfun.altrua.features.user.domain.User;
 import com.techfun.altrua.features.user.service.UserService;
-import com.techfun.altrua.infra.security.userdetails.UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,21 +26,18 @@ public class UserController {
     private final UserService userService;
 
     /**
-     * Retorna os dados do usuário autenticado.
+     * Obtém as informações do perfil do usuário autenticado.
      *
      * <p>
-     * Extrai o usuário diretamente do {@link UserPrincipal} populado pelo filtro
-     * JWT,
-     * evitando consulta adicional ao banco de dados.
+     * O identificador é extraído do contexto de segurança atual. Realiza uma
+     * consulta ao banco de dados para garantir que as informações retornadas
+     * estejam sincronizadas com o estado mais recente do registro.
      * </p>
-     *
-     * @param userPrincipal o principal do usuário autenticado extraído do contexto
-     *                      de segurança
-     * @return {@link ResponseEntity} contendo os dados do usuário sem a senha
+     * * @return {@link UserResponseDTO} contendo os detalhes do perfil do usuário.
      */
     @GetMapping("/me")
-    public ResponseEntity<UserResponseDTO> getCurrentUser(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return ResponseEntity.ok(userService.getMe(userPrincipal.getUser()));
+    public ResponseEntity<UserResponseDTO> getCurrentUser() {
+        return ResponseEntity.ok(userService.getMe());
     }
 
 }

--- a/backend/src/main/java/com/techfun/altrua/features/user/api/dto/UserResponseDTO.java
+++ b/backend/src/main/java/com/techfun/altrua/features/user/api/dto/UserResponseDTO.java
@@ -20,16 +20,27 @@ import com.techfun.altrua.features.user.domain.User;
  * @param createdAt data e hora de criação do registro
  * @param updatedAt data e hora da última atualização do registro
  */
-public record UserResponseDTO(UUID id, String name, String email, String avatarUrl, Instant createdAt,
+public record UserResponseDTO(
+        UUID id,
+        String name,
+        String email,
+        String avatarUrl,
+        Instant createdAt,
         Instant updatedAt) {
 
     /**
-     * Cria um {@link UserResponseDTO} a partir de uma entidade {@link User}.
+     * Converte uma instância da entidade {@link User} para {@link UserResponseDTO}.
      *
-     * @param user a entidade do usuário
+     * @param user a entidade original proveniente do banco de dados
+     * @return uma nova instância de DTO com os dados mapeados
      */
-    public UserResponseDTO(User user) {
-        this(user.getId(), user.getName(), user.getEmail(), user.getAvatarUrl(), user.getCreatedAt(),
+    public static UserResponseDTO fromEntity(User user) {
+        return new UserResponseDTO(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getAvatarUrl(),
+                user.getCreatedAt(),
                 user.getUpdatedAt());
     }
 

--- a/backend/src/main/java/com/techfun/altrua/features/user/service/UserService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/user/service/UserService.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.techfun.altrua.core.common.exceptions.DomainException;
+import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
 import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.features.user.api.dto.UserResponseDTO;
 import com.techfun.altrua.features.user.domain.User;
@@ -33,12 +33,13 @@ public class UserService {
      * </p>
      *
      * @return {@link UserResponseDTO} contendo os dados atuais do usuário.
-     * @throws DomainException se o identificador do usuário no contexto
-     *                         não existir na base.
+     * @throws ResourceNotFoundException se o identificador do usuário no contexto
+     *                                   não existir na base.
      */
     public UserResponseDTO getMe() {
         UUID userId = SecurityUtils.getCurrentUserId();
-        User user = userRepository.findById(userId).orElseThrow(() -> new DomainException("Usuário não encontrado"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário"));
         return UserResponseDTO.fromEntity(user);
     }
 }

--- a/backend/src/main/java/com/techfun/altrua/features/user/service/UserService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/user/service/UserService.java
@@ -1,29 +1,44 @@
 package com.techfun.altrua.features.user.service;
 
-import org.springframework.stereotype.Service;
+import java.util.UUID;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.techfun.altrua.core.common.exceptions.DomainException;
+import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.features.user.api.dto.UserResponseDTO;
 import com.techfun.altrua.features.user.domain.User;
+import com.techfun.altrua.features.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * Serviço responsável pelas regras de negócio relacionadas aos usuários.
  */
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
+    private final UserRepository userRepository;
+
     /**
-     * Retorna os dados do usuário autenticado.
+     * Recupera o perfil do usuário atualmente autenticado na sessão.
      *
      * <p>
-     * Converte a entidade {@link User} para {@link UserResponseDTO},
-     * sem realizar consulta adicional ao banco de dados.
+     * Este método garante a integridade dos dados ao realizar uma consulta
+     * atualizada ao banco de dados, evitando o uso de informações possivelmente
+     * obsoletas contidas no token ou no contexto de segurança.
      * </p>
      *
-     * @param user a entidade do usuário autenticado
-     * @return {@link UserResponseDTO} com os dados públicos do usuário
+     * @return {@link UserResponseDTO} contendo os dados atuais do usuário.
+     * @throws DomainException se o identificador do usuário no contexto
+     *                         não existir na base.
      */
-    public UserResponseDTO getMe(User user) {
-        return new UserResponseDTO(user);
+    public UserResponseDTO getMe() {
+        UUID userId = SecurityUtils.getCurrentUserId();
+        User user = userRepository.findById(userId).orElseThrow(() -> new DomainException("Usuário não encontrado"));
+        return UserResponseDTO.fromEntity(user);
     }
-
 }

--- a/backend/src/main/java/com/techfun/altrua/infra/config/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/techfun/altrua/infra/config/handler/GlobalExceptionHandler.java
@@ -25,6 +25,7 @@ import com.techfun.altrua.core.common.exceptions.DuplicateResourceException;
 import com.techfun.altrua.core.common.exceptions.ForbiddenActionException;
 import com.techfun.altrua.core.common.exceptions.InvalidCredentialsException;
 import com.techfun.altrua.core.common.exceptions.RefreshTokenException;
+import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
 import com.techfun.altrua.infra.security.handler.CustomAuthenticationEntryPoint;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -199,6 +200,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     /**
+     * Trata tentativas de acesso a recursos que não existem no sistema.
+     *
+     * @param ex Exceção de recurso não encontrado.
+     * @return {@link ProblemDetail} com status 404 Not Found.
+     */
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ProblemDetail handleResourceNotFound(ResourceNotFoundException ex) {
+        return buildProblemDetail(ex.getStatus(), ex.getMessage(), "Recurso não encontrado");
+    }
+
+    /**
      * Sobrescreve o tratamento de erros de validação do Bean Validation (@Valid).
      * 
      * <p>
@@ -221,7 +233,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                         FieldError::getDefaultMessage,
                         (existingMessage, newMessage) -> existingMessage));
 
-        problem.setProperty("invalid_params", fields);
+        problem.setProperty("campos_invalidos", fields);
         return ResponseEntity.status(status).body(problem);
     }
 

--- a/backend/src/main/java/com/techfun/altrua/infra/config/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/techfun/altrua/infra/config/handler/GlobalExceptionHandler.java
@@ -233,7 +233,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                         FieldError::getDefaultMessage,
                         (existingMessage, newMessage) -> existingMessage));
 
-        problem.setProperty("campos_invalidos", fields);
+        problem.setProperty("invalid_params", fields);
         return ResponseEntity.status(status).body(problem);
     }
 

--- a/backend/src/main/java/com/techfun/altrua/infra/security/SecurityService.java
+++ b/backend/src/main/java/com/techfun/altrua/infra/security/SecurityService.java
@@ -3,8 +3,11 @@ package com.techfun.altrua.infra.security;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
 import com.techfun.altrua.core.common.util.SecurityUtils;
+import com.techfun.altrua.features.event.domain.model.Event;
 import com.techfun.altrua.features.event.repository.EventRepository;
 import com.techfun.altrua.features.ong.domain.model.OngAdministratorId;
 import com.techfun.altrua.features.ong.repository.OngAdministratorRepository;
@@ -43,19 +46,36 @@ public class SecurityService {
     }
 
     /**
-     * Verifica se o usuário autenticado tem permissão para gerenciar um evento.
+     * Valida se o usuário autenticado possui permissão para gerenciar um evento
+     * específico.
      * <p>
-     * A permissão é concedida se o usuário for administrador da ONG proprietária do
-     * evento.
+     * O método verifica a existência do evento e sua vinculação à ONG informada.
+     * A permissão é concedida apenas se o usuário for um administrador da ONG
+     * proprietária.
      * </p>
+     *
+     * @param ongId   Identificador da ONG para validação de integridade da rota.
+     * @param eventId Identificador do evento a ser gerenciado.
+     * @return {@code true} se o acesso for autorizado.
+     * @throws ResourceNotFoundException Se o evento não existir ou não pertencer à
+     *                                   ONG informada.
      */
-    public boolean canManageEvent(UUID eventId) {
+    @Transactional(readOnly = true)
+    public boolean canManageEvent(UUID ongId, UUID eventId) {
+        Event event = eventRepository.findByIdWithOngAndAdmins(eventId)
+                .orElseThrow(() -> new ResourceNotFoundException("Evento"));
+
+        if (!event.getOng().getId().equals(ongId)) {
+            throw new ResourceNotFoundException("Evento");
+        }
+
         UUID userId = SecurityUtils.getCurrentUserId();
 
-        boolean canManage = eventRepository.existsByIdAndOng_Administrators_User_Id(eventId, userId);
+        boolean canManage = event.getOng().getAdministrators().stream()
+                .anyMatch(admin -> admin.getUser().getId().equals(userId));
 
         if (!canManage) {
-            log.warn("Acesso negado: Usuário {} tentou gerenciar o evento {}", userId, eventId);
+            log.warn("Acesso negado: Usuário {} tentou gerenciar o evento {} da ONG {}", userId, eventId, ongId);
         }
 
         return canManage;

--- a/backend/src/main/java/com/techfun/altrua/infra/security/SecurityService.java
+++ b/backend/src/main/java/com/techfun/altrua/infra/security/SecurityService.java
@@ -1,0 +1,64 @@
+package com.techfun.altrua.infra.security;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.techfun.altrua.core.common.util.SecurityUtils;
+import com.techfun.altrua.features.event.repository.EventRepository;
+import com.techfun.altrua.features.ong.domain.model.OngAdministratorId;
+import com.techfun.altrua.features.ong.repository.OngAdministratorRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Serviço de suporte à autorização para validação de permissões de acesso.
+ * <p>
+ * Utilizado principalmente em expressões SpEL dentro de anotações
+ * {@code @PreAuthorize}.
+ * </p>
+ */
+@Slf4j
+@Service("securityService")
+@RequiredArgsConstructor
+public class SecurityService {
+
+    private final OngAdministratorRepository ongAdministratorRepository;
+    private final EventRepository eventRepository;
+
+    /**
+     * Verifica se o usuário autenticado é administrador de uma ONG específica.
+     */
+    public boolean isOngAdmin(UUID ongId) {
+        UUID userId = SecurityUtils.getCurrentUserId();
+
+        boolean isAdmin = ongAdministratorRepository.existsById(new OngAdministratorId(userId, ongId));
+
+        if (!isAdmin) {
+            log.warn("Acesso negado: Usuário {} tentou gerenciar a ONG {}", userId, ongId);
+        }
+
+        return isAdmin;
+    }
+
+    /**
+     * Verifica se o usuário autenticado tem permissão para gerenciar um evento.
+     * <p>
+     * A permissão é concedida se o usuário for administrador da ONG proprietária do
+     * evento.
+     * </p>
+     */
+    public boolean canManageEvent(UUID eventId) {
+        UUID userId = SecurityUtils.getCurrentUserId();
+
+        boolean canManage = eventRepository.existsByIdAndOng_Administrators_User_Id(eventId, userId);
+
+        if (!canManage) {
+            log.warn("Acesso negado: Usuário {} tentou gerenciar o evento {}", userId, eventId);
+        }
+
+        return canManage;
+    }
+
+}


### PR DESCRIPTION
## Resumo

Implementação do endpoint para encerramento de eventos e criação de utilitário centralizado para gestão de contexto de segurança.

## Alterações Principais

- **SecurityUtils**: Classe utilitária para extrair o `userId` do `SecurityContext` de forma padronizada, com tratamento de exceções de autenticação.
- **SecurityService**: Novos métodos de validação para verificar se o usuário é administrador de uma ONG ou possui permissão sobre um evento específico.
- **EventController / EventService**: Criação do endpoint `POST /ongs/{ongId}/eventos/{eventId}/encerrar` com proteção via `@PreAuthorize`.
- **Domínio**: Implementação da lógica de encerramento na entidade `Event`.

## Endpoints Adicionados

- `POST /ongs/{ongId}/eventos/{eventId}/encerrar`  
  Requer permissão de administrador da ONG proprietária.