### PR TITLE
Gerenciamento de inscrições de voluntários

### DIFF
--- a/backend/src/main/java/com/techfun/altrua/features/auth/domain/RefreshToken.java
+++ b/backend/src/main/java/com/techfun/altrua/features/auth/domain/RefreshToken.java
@@ -17,7 +17,6 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * Entidade que representa um refresh token no sistema.
@@ -35,25 +34,21 @@ import lombok.Setter;
 @Entity
 @Table(name = "refresh_tokens")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
 
     /** Identificador único do refresh token, gerado automaticamente como UUID. */
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Setter(AccessLevel.NONE)
     private UUID id;
 
     /** Valor do refresh token JWT. Deve ser único no sistema. */
     @Column(nullable = false, unique = true, length = 64)
-    @Setter(AccessLevel.NONE)
     private String token;
 
     /** Usuário vinculado ao refresh token. */
     @ManyToOne
     @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
-    @Setter(AccessLevel.NONE)
     private User user;
 
     /** Data e hora de expiração do token. */
@@ -65,7 +60,6 @@ public class RefreshToken {
      * e não pode ser alterada.
      */
     @Column(name = "created_at", nullable = false, updatable = false)
-    @Setter(AccessLevel.NONE)
     private Instant createdAt;
 
     /**

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventVolunteerController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventVolunteerController.java
@@ -1,0 +1,89 @@
+package com.techfun.altrua.features.event.api;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.techfun.altrua.features.event.service.EventVolunteerService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Expõe os endpoints para que usuários realizem e gerenciem suas inscrições em
+ * eventos de ONGs.
+ * <p>
+ * A classe atua como a camada de entrada para as operações de voluntariado,
+ * traduzindo as requisições HTTP em chamadas de serviço e garantindo que o
+ * contexto da ONG e do Evento sejam respeitados através dos caminhos da URL.
+ * </p>
+ */
+@Tag(name = "Voluntários", description = "Inscrição e gerenciamento de voluntários em eventos")
+@RestController
+@RequestMapping("/ongs/{ongId}/eventos/{eventId}/volunteers")
+@RequiredArgsConstructor
+public class EventVolunteerController {
+
+    private final EventVolunteerService eventVolunteerService;
+
+    /**
+     * Endpoint para processar a solicitação de inscrição do usuário autenticado.
+     * <p>
+     * Invoca a lógica de inscrição que valida capacidade e duplicidade sob controle
+     * de transação.
+     * </p>
+     * 
+     * @param ongId   Identificador da organização responsável.
+     * @param eventId Identificador do evento alvo.
+     * @return Resposta HTTP 201 em caso de sucesso.
+     */
+    @Operation(summary = "Inscrever-se em um evento", description = "Realiza a inscrição do usuário logado como voluntário em um evento específico.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Inscrição realizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Regra de negócio violada (Evento lotado ou usuário já inscrito)"),
+            @ApiResponse(responseCode = "404", description = "Evento ou ONG não encontrados"),
+            @ApiResponse(responseCode = "401", description = "Usuário não autenticado"),
+    })
+    @PostMapping
+    public ResponseEntity<Void> enroll(
+            @Parameter(description = "ID da ONG proprietária do evento") @PathVariable("ongId") UUID ongId,
+            @Parameter(description = "ID do evento") @PathVariable("eventId") UUID eventId) {
+        eventVolunteerService.enroll(eventId, ongId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
+     * Endpoint para revogar a participação de um voluntário.
+     * <p>
+     * O cancelamento é restrito ao vínculo específico entre o usuário logado e o
+     * evento dentro do contexto da ONG informada.
+     * </p>
+     * 
+     * @param ongId   Identificador da organização responsável.
+     * @param eventId Identificador do evento do qual o usuário deseja sair.
+     * @return Resposta HTTP 204 em caso de sucesso.
+     */
+    @Operation(summary = "Cancelar inscrição em um evento", description = "Remove a participação do usuário logado como voluntário.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Inscrição cancelada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Inscrição não encontrada para este evento no contexto desta ONG"),
+            @ApiResponse(responseCode = "401", description = "Usuário não autenticado"),
+    })
+    @DeleteMapping
+    public ResponseEntity<Void> unenroll(
+            @Parameter(description = "ID da ONG proprietária do evento") @PathVariable("ongId") UUID ongId,
+            @Parameter(description = "ID do evento no qual o usuário está inscrito") @PathVariable("eventId") UUID eventId) {
+        eventVolunteerService.cancelEnrollment(eventId, ongId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/dto/RegisterEventRequestDTO.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/dto/RegisterEventRequestDTO.java
@@ -10,6 +10,7 @@ import com.techfun.altrua.features.ong.domain.model.Ong;
 import com.techfun.altrua.features.user.domain.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -79,10 +80,33 @@ public record RegisterEventRequestDTO(
         @Schema(description = "Conjunto de nomes das tags para categorização", example = "[\"Meio Ambiente\", \"Limpeza\"]") @NotEmpty(message = "É obrigatório informar ao menos uma tag") Set<@NotBlank(message = "O nome da tag não pode estar em branco") String> tags) {
 
     /**
+     * Valida a consistência entre {@code acceptsVolunteers} e
+     * {@code maxVolunteers}.
+     * <p>
+     * Quando o evento aceita voluntários, {@code maxVolunteers} deve ser informado
+     * e conter um valor maior que zero. Caso {@code acceptsVolunteers} seja
+     * {@code false} ou {@code null}, o campo é ignorado.
+     * </p>
+     *
+     * @return {@code true} se a combinação dos campos for válida; {@code false}
+     *         caso contrário.
+     */
+    @AssertTrue(message = "Número máximo de voluntários é obrigatório e deve ser maior que zero quando o evento aceitar voluntários")
+    private boolean isMaxVolunteersValid() {
+        return !Boolean.TRUE.equals(acceptsVolunteers) || maxVolunteers != null && maxVolunteers > 0;
+    }
+
+    /**
      * Mapeia os dados do DTO para uma nova instância da entidade {@link Event}.
      * 
      * <p>
      * Por padrão, novos eventos são criados com o status {@code PUBLISHED}.
+     * </p>
+     *
+     * <p>
+     * O campo {@code maxVolunteers} só é repassado à entidade quando
+     * {@code acceptsVolunteers} for {@code true}; caso contrário, é persistido
+     * como {@code null}, independentemente do valor informado na requisição.
      * </p>
      *
      * @param slug    O slug único gerado previamente para o evento.
@@ -103,7 +127,7 @@ public record RegisterEventRequestDTO(
                 .donationInfo(this.donationInfo)
                 .donationExternalLink(this.donationExternalLink)
                 .acceptsVolunteers(this.acceptsVolunteers)
-                .maxVolunteers(this.maxVolunteers)
+                .maxVolunteers(Boolean.TRUE.equals(this.acceptsVolunteers) ? this.maxVolunteers : null)
                 .latitude(this.latitude)
                 .longitude(this.longitude)
                 .addressLabel(this.addressLabel)

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/enums/VolunteerStatusEnum.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/enums/VolunteerStatusEnum.java
@@ -1,0 +1,17 @@
+package com.techfun.altrua.features.event.domain.enums;
+
+/**
+ * Define os possíveis estados de uma inscrição de voluntário no sistema.
+ * <p>
+ * CONFIRMED indica que a inscrição está ativa e contabiliza para o limite de
+ * vagas do evento, enquanto CANCELLED representa a desistência ou remoção do
+ * voluntário, liberando a vaga para novos ingressos.
+ * </p>
+ */
+public enum VolunteerStatusEnum {
+    /** Inscrição ativa e válida para participação no evento. */
+    CONFIRMED,
+
+    /** Inscrição inativa após solicitação de cancelamento. */
+    CANCELLED
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Event.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Event.java
@@ -63,108 +63,109 @@ import lombok.Setter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Event {
 
+    /** Identificador único universal do evento. */
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Setter(AccessLevel.NONE)
-    /** Identificador único universal do evento. */
     private UUID id;
 
+    /** ONG responsável pela organização e gestão do evento. */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ong_id", nullable = false)
-    /** ONG responsável pela organização e gestão do evento. */
+    @Setter(AccessLevel.NONE)
     private Ong ong;
 
+    /** Usuário administrador que realizou o cadastro inicial do evento. */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by_user_id", nullable = false, updatable = false)
     @Setter(AccessLevel.NONE)
-    /** Usuário administrador que realizou o cadastro inicial do evento. */
     private User createdByUser;
 
+    /** Coleção de etiquetas (tags) associadas para categorização e busca. */
     @Builder.Default
     @ManyToMany(fetch = FetchType.LAZY, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinTable(name = "event_tags", joinColumns = @JoinColumn(name = "event_id"), inverseJoinColumns = @JoinColumn(name = "tag_id"))
     @Setter(AccessLevel.NONE)
-    /** Coleção de etiquetas (tags) associadas para categorização e busca. */
     private Set<Tag> tags = new HashSet<>();
 
-    @Column(nullable = false)
     /** Título público do evento. */
+    @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
-    @Setter(AccessLevel.NONE)
     /** Identificador único textual para composição de URLs amigáveis. */
+    @Column(nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private String slug;
 
-    @Column(columnDefinition = "TEXT")
     /** Descrição detalhada sobre os objetivos e atividades do evento. */
+    @Column(columnDefinition = "TEXT")
     private String description;
 
+    /** Estado atual do ciclo de vida do evento (ex: PUBLISHED, CANCELED). */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    /** Estado atual do ciclo de vida do evento (ex: PUBLISHED, CANCELED). */
     private EventStatusEnum status;
 
-    @Column(name = "cover_url", length = 500)
     /** URL da imagem principal ou banner de divulgação. */
+    @Column(name = "cover_url", length = 500)
     private String coverUrl;
 
-    @Column(name = "external_link", length = 500)
     /** Link opcional para páginas externas de inscrição ou detalhes. */
+    @Column(name = "external_link", length = 500)
     private String externalLink;
 
-    @Column(name = "donation_info", columnDefinition = "TEXT")
     /** Informações e instruções sobre como realizar doações para o evento. */
+    @Column(name = "donation_info", columnDefinition = "TEXT")
     private String donationInfo;
 
-    @Column(name = "donation_external_link", length = 500)
     /** Link direto para plataformas externas de arrecadação financeira. */
+    @Column(name = "donation_external_link", length = 500)
     private String donationExternalLink;
 
-    @Column(name = "accepts_volunteers", nullable = false)
     /** Indica se o evento permite a inscrição de novos voluntários. */
+    @Column(name = "accepts_volunteers", nullable = false)
     private boolean acceptsVolunteers;
 
-    @Column(name = "max_volunteers")
     /** Quantidade máxima de voluntários permitida (opcional). */
+    @Column(name = "max_volunteers")
     private Integer maxVolunteers;
 
-    @Column(precision = 10, scale = 8)
     /** Coordenada de latitude para representação em mapas. */
+    @Column(precision = 10, scale = 8)
     private BigDecimal latitude;
 
-    @Column(precision = 11, scale = 8)
     /** Coordenada de longitude para representação em mapas. */
+    @Column(precision = 11, scale = 8)
     private BigDecimal longitude;
 
-    @Column(name = "address_label")
     /** Descrição textual do local (Ex: Praça Central ou nome da rua). */
+    @Column(name = "address_label")
     private String addressLabel;
 
-    @Column(name = "starts_at", nullable = false)
     /** Data e hora de início das atividades. */
+    @Column(name = "starts_at", nullable = false)
     private Instant startsAt;
 
-    @Column(name = "ends_at")
     /** Data e hora de encerramento previsto das atividades. */
+    @Column(name = "ends_at")
     private Instant endsAt;
 
+    /** Carimbo de data/hora de quando o registro foi criado no banco. */
     @Column(name = "created_at", nullable = false, updatable = false)
     @Setter(AccessLevel.NONE)
-    /** Carimbo de data/hora de quando o registro foi criado no banco. */
     private Instant createdAt;
 
+    /** Carimbo de data/hora da última modificação realizada no registro. */
     @Column(name = "updated_at", nullable = false)
     @Setter(AccessLevel.NONE)
-    /** Carimbo de data/hora da última modificação realizada no registro. */
     private Instant updatedAt;
 
-    @Column(name = "deleted_at")
-    @Setter(AccessLevel.NONE)
     /**
      * Carimbo de data/hora da exclusão lógica (Soft Delete). Se nulo, o registro
      * está ativo.
      */
+    @Column(name = "deleted_at")
+    @Setter(AccessLevel.NONE)
     private Instant deletedAt;
 
     /**
@@ -190,6 +191,26 @@ public class Event {
         }
 
         this.status = EventStatusEnum.FINISHED;
+    }
+
+    /**
+     * Valida a disponibilidade de vagas e a permissão de ingresso no evento.
+     * <p>
+     * Retorna verdadeiro apenas se o evento estiver configurado para aceitar
+     * participantes e o total de inscritos ativos for estritamente menor que a
+     * capacidade máxima estabelecida.
+     * </p>
+     * <p>
+     * A precisão desta verificação depende de um contador de voluntários
+     * consistente, preferencialmente obtido via lock pessimista para evitar
+     * violações de limite em processamentos paralelos.
+     * </p>
+     * * @param activeCount Total de inscrições com status confirmado.
+     * 
+     * @return Estado da disponibilidade de vagas para novos voluntários.
+     */
+    public boolean acceptsNewVolunteers(long activeCount) {
+        return this.acceptsVolunteers && activeCount < this.maxVolunteers;
     }
 
     /**

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Event.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Event.java
@@ -205,7 +205,8 @@ public class Event {
      * consistente, preferencialmente obtido via lock pessimista para evitar
      * violações de limite em processamentos paralelos.
      * </p>
-     * * @param activeCount Total de inscrições com status confirmado.
+     * 
+     * @param activeCount Total de inscrições com status confirmado.
      * 
      * @return Estado da disponibilidade de vagas para novos voluntários.
      */

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/model/EventVolunteer.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/model/EventVolunteer.java
@@ -103,7 +103,8 @@ public class EventVolunteer {
     }
 
     /**
-     * Define o instante de criação do registro no momento da persistência inicial.
+     * Define o instante de confirmação do registro no momento da persistência
+     * inicial.
      */
     @PrePersist
     private void onPersist() {
@@ -111,11 +112,14 @@ public class EventVolunteer {
     }
 
     /**
-     * Atualiza o carimbo de confirmação sempre que houver modificações no registro,
-     * mantendo a última interação rastreada.
+     * Atualiza o carimbo de confirmação apenas quando o status for CONFIRMED,
+     * evitando que operações de cancelamento sobrescrevam o instante
+     * da última confirmação ou reativação.
      */
     @PreUpdate
     private void onUpdate() {
-        this.confirmedAt = Instant.now();
+        if (this.status == VolunteerStatusEnum.CONFIRMED) {
+            this.confirmedAt = Instant.now();
+        }
     }
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/model/EventVolunteer.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/model/EventVolunteer.java
@@ -1,0 +1,121 @@
+package com.techfun.altrua.features.event.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.techfun.altrua.features.event.domain.enums.VolunteerStatusEnum;
+import com.techfun.altrua.features.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Representa o vínculo de inscrição entre um voluntário e um evento específico.
+ * <p>
+ * Esta entidade gerencia o ciclo de vida da participação, permitindo o controle
+ * de estados entre confirmação e cancelamento, além de registrar carimbos de
+ * data/hora para auditoria. A integridade das inscrições duplicadas é garantida
+ * por restrições de unicidade no banco de dados entre as colunas de evento e
+ * usuário.
+ * </p>
+ */
+@Entity
+@Table(name = "event_volunteers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventVolunteer {
+
+    /** Identificador único da inscrição no formato UUID. */
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /** Referência ao evento que disponibiliza a vaga. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false, updatable = false)
+    private Event event;
+
+    /** Usuário voluntário vinculado à inscrição. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, updatable = false)
+    private User user;
+
+    /** Estado atual da participação (ex: CONFIRMED, CANCELLED). */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private VolunteerStatusEnum status;
+
+    /** Instante da última confirmação ou reativação da inscrição. */
+    @Column(name = "confirmed_at", nullable = false)
+    private Instant confirmedAt;
+
+    /** Registro temporal de quando o usuário solicitou o cancelamento. */
+    @Column(name = "cancelled_at")
+    private Instant cancelledAt;
+
+    private EventVolunteer(Event event, User user) {
+        this.event = event;
+        this.user = user;
+        this.status = VolunteerStatusEnum.CONFIRMED;
+    }
+
+    /**
+     * Cria uma nova instância de inscrição com o estado inicial confirmado.
+     * 
+     * @param event O evento ao qual o voluntário está se vinculando.
+     * @param user  O usuário que está realizando a inscrição.
+     * @return Uma nova instância de EventVolunteer configurada.
+     */
+    public static EventVolunteer enroll(Event event, User user) {
+        return new EventVolunteer(event, user);
+    }
+
+    /**
+     * Altera o status da inscrição para cancelado e registra o instante da
+     * operação.
+     */
+    public void cancel() {
+        this.status = VolunteerStatusEnum.CANCELLED;
+        this.cancelledAt = Instant.now();
+    }
+
+    /**
+     * Reverte um cancelamento anterior, restaurando o status para confirmado e
+     * removendo a data de cancelamento.
+     */
+    public void reactivate() {
+        this.status = VolunteerStatusEnum.CONFIRMED;
+        this.cancelledAt = null;
+    }
+
+    /**
+     * Define o instante de criação do registro no momento da persistência inicial.
+     */
+    @PrePersist
+    private void onPersist() {
+        this.confirmedAt = Instant.now();
+    }
+
+    /**
+     * Atualiza o carimbo de confirmação sempre que houver modificações no registro,
+     * mantendo a última interação rastreada.
+     */
+    @PreUpdate
+    private void onUpdate() {
+        this.confirmedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Tag.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/domain/model/Tag.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * Entidade que representa uma etiqueta ou categoria de classificação para
@@ -34,15 +33,13 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tag {
 
+    /** Identificador único da tag. */
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Setter(AccessLevel.NONE)
-    /** Identificador único da tag. */
     private UUID id;
 
-    @Column(nullable = false, unique = true)
-    @Setter(AccessLevel.NONE)
     /** Nome da tag em formato normalizado (lowercase e sem espaços extras). */
+    @Column(nullable = false, unique = true)
     private String name;
 
     /**

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
@@ -63,9 +63,9 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
      * organizações. O bloqueio impede que outros processos modifiquem o evento até
      * o fim da transação atual.
      * </p>
-     * * @param eventId Identificador único do evento.
      * 
-     * @param ongId Identificador da ONG proprietária do evento.
+     * @param eventId Identificador único do evento.
+     * @param ongId   Identificador da ONG proprietária do evento.
      * @return Um Optional contendo o evento encontrado ou vazio caso a relação
      *         ID/ONG seja inválida.
      */

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
@@ -4,10 +4,13 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.techfun.altrua.features.event.domain.model.Event;
+
+import jakarta.persistence.LockModeType;
 
 /**
  * Interface de repositório para a entidade {@link Event}.
@@ -49,5 +52,24 @@ public interface EventRepository extends JpaRepository<Event, UUID> {
      *         não encontrado.
      */
     @Query("SELECT e FROM Event e JOIN FETCH e.ong o LEFT JOIN FETCH o.administrators a WHERE e.id = :eventId")
-    Optional<Event> findByIdWithOngAndAdmins(@Param("eventId") UUID eventId);
+    public Optional<Event> findByIdWithOngAndAdmins(@Param("eventId") UUID eventId);
+
+    /**
+     * Recupera um evento específico sob lock pessimista de escrita para garantir
+     * consistência em operações concorrentes.
+     * <p>
+     * A consulta valida simultaneamente a existência do evento e seu vínculo com a
+     * ONG informada, prevenindo acessos indevidos a recursos de outras
+     * organizações. O bloqueio impede que outros processos modifiquem o evento até
+     * o fim da transação atual.
+     * </p>
+     * * @param eventId Identificador único do evento.
+     * 
+     * @param ongId Identificador da ONG proprietária do evento.
+     * @return Um Optional contendo o evento encontrado ou vazio caso a relação
+     *         ID/ONG seja inválida.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.id = :eventId AND e.ong.id = :ongId")
+    public Optional<Event> findByIdAndOngIdForUpdate(@Param("eventId") UUID eventId, @Param("ongId") UUID ongId);
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventVolunteerRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventVolunteerRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.techfun.altrua.features.event.domain.enums.VolunteerStatusEnum;
 import com.techfun.altrua.features.event.domain.model.EventVolunteer;
 
 import jakarta.persistence.LockModeType;
@@ -19,17 +20,21 @@ import jakarta.persistence.LockModeType;
 public interface EventVolunteerRepository extends JpaRepository<EventVolunteer, UUID> {
 
     /**
-     * Contabiliza o total de inscrições confirmadas para um evento específico.
+     * Contabiliza o total de inscrições para um evento específico filtrando pelo
+     * status informado.
      * <p>
-     * Utilizado para validar o limite de vagas antes de permitir novos ingressos no
-     * sistema.
+     * Utilizado para validar o limite de vagas (quando o status é CONFIRMED) ou
+     * para métricas de cancelamento antes de processar novas operações de
+     * inscrição.
      * </p>
      * 
-     * @param eventId Identificador do evento.
-     * @return Quantidade total de voluntários com status CONFIRMED.
+     * @param eventId Identificador único do evento.
+     * @param status  Estado da inscrição a ser contabilizado (ex: CONFIRMED,
+     *                CANCELLED).
+     * @return Quantidade total de voluntários que atendem aos critérios de filtro.
      */
-    @Query("SELECT COUNT(ev) FROM EventVolunteer ev WHERE ev.event.id = :eventId AND ev.status = 'CONFIRMED'")
-    public long countActiveByEventId(@Param("eventId") UUID eventId);
+    @Query("SELECT COUNT(ev) FROM EventVolunteer ev WHERE ev.event.id = :eventId AND ev.status = :status")
+    public long countByEventIdAndStatus(@Param("eventId") UUID eventId, @Param("status") VolunteerStatusEnum status);
 
     /**
      * Recupera o vínculo de inscrição entre um evento e um usuário sem aplicar

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventVolunteerRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventVolunteerRepository.java
@@ -1,0 +1,65 @@
+package com.techfun.altrua.features.event.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.techfun.altrua.features.event.domain.model.EventVolunteer;
+
+import jakarta.persistence.LockModeType;
+
+/**
+ * Interface de persistência para a entidade EventVolunteer, fornecendo métodos
+ * de consulta otimizados e controle de concorrência.
+ */
+public interface EventVolunteerRepository extends JpaRepository<EventVolunteer, UUID> {
+
+    /**
+     * Contabiliza o total de inscrições confirmadas para um evento específico.
+     * <p>
+     * Utilizado para validar o limite de vagas antes de permitir novos ingressos no
+     * sistema.
+     * </p>
+     * 
+     * @param eventId Identificador do evento.
+     * @return Quantidade total de voluntários com status CONFIRMED.
+     */
+    @Query("SELECT COUNT(ev) FROM EventVolunteer ev WHERE ev.event.id = :eventId AND ev.status = 'CONFIRMED'")
+    public long countActiveByEventId(@Param("eventId") UUID eventId);
+
+    /**
+     * Recupera o vínculo de inscrição entre um evento e um usuário sem aplicar
+     * bloqueios.
+     * 
+     * @param eventId Identificador do evento.
+     * @param userId  Identificador do usuário voluntário.
+     * @return Um Optional contendo a inscrição, se existente.
+     */
+    public Optional<EventVolunteer> findByEventIdAndUserId(UUID eventId, UUID userId);
+
+    /**
+     * Recupera uma inscrição específica sob lock pessimista de escrita, validando o
+     * contexto da ONG proprietária.
+     * <p>
+     * O uso do JOIN garante que a operação de cancelamento ou alteração respeite a
+     * hierarquia entre ONG e Evento, prevenindo manipulações indevidas de recursos
+     * cruzados.
+     * </p>
+     * 
+     * @param eventId Identificador do evento.
+     * @param ongId   Identificador da ONG responsável pelo evento.
+     * @param userId  Identificador do voluntário.
+     * @return Um Optional com a inscrição encontrada sob bloqueio para atualização
+     *         segura.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ev FROM EventVolunteer ev JOIN ev.event e WHERE e.id = :eventId AND e.ong.id = :ongId AND ev.user.id = :userId")
+    public Optional<EventVolunteer> findByEventIdAndOngIdAndUserIdForUpdate(
+            @Param("eventId") UUID eventId,
+            @Param("ongId") UUID ongId,
+            @Param("userId") UUID userId);
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventVolunteerService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventVolunteerService.java
@@ -3,6 +3,7 @@ package com.techfun.altrua.features.event.service;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,31 +41,37 @@ public class EventVolunteerService {
     /**
      * Realiza a inscrição ou reativação de um voluntário em um evento específico.
      * <p>
-     * O método valida se o usuário já possui inscrição ativa, se o evento pertence
-     * à ONG informada e se há vagas disponíveis sob lock de escrita. Caso uma
-     * inscrição prévia cancelada seja encontrada, ela é reativada; caso contrário,
-     * um novo registro é persistido.
+     * Antes de qualquer operação, verifica se o evento pertence à ONG informada
+     * adquirindo um lock pessimista de escrita, garantindo que verificações de
+     * vagas e persistência sejam atômicas sob concorrência.
      * </p>
-     * 
+     * <p>
+     * Se uma inscrição prévia cancelada for encontrada, ela é reativada. Caso
+     * contrário, um novo registro é persistido. Uma violação de unicidade no banco
+     * é capturada como salvaguarda contra requisições paralelas com o mesmo
+     * usuário.
+     * </p>
+     *
      * @param eventId Identificador do evento alvo.
      * @param ongId   Identificador da ONG proprietária do evento.
-     * @throws DomainException           Se o usuário já estiver inscrito ou se o
-     *                                   limite de vagas for atingido.
      * @throws ResourceNotFoundException Se o evento não for localizado no contexto
      *                                   da ONG informada.
+     * @throws DomainException           Se o usuário já possuir inscrição ativa,
+     *                                   ou se o limite de vagas tiver sido
+     *                                   atingido.
      */
     @Transactional
     public void enroll(UUID eventId, UUID ongId) {
         UUID currentUserId = SecurityUtils.getCurrentUserId();
+
+        Event event = eventRepository.findByIdAndOngIdForUpdate(eventId, ongId)
+                .orElseThrow(() -> new ResourceNotFoundException("Evento"));
 
         Optional<EventVolunteer> existing = eventVolunteerRepository.findByEventIdAndUserId(eventId, currentUserId);
 
         if (existing.isPresent() && existing.get().getStatus() == VolunteerStatusEnum.CONFIRMED) {
             throw new DomainException("Você já está inscrito nesse evento");
         }
-
-        Event event = eventRepository.findByIdAndOngIdForUpdate(eventId, ongId)
-                .orElseThrow(() -> new ResourceNotFoundException("Evento"));
 
         long activeCount = eventVolunteerRepository.countByEventIdAndStatus(eventId, VolunteerStatusEnum.CONFIRMED);
         if (!event.acceptsNewVolunteers(activeCount)) {
@@ -76,8 +83,12 @@ public class EventVolunteerService {
             volunteer.reactivate();
             eventVolunteerRepository.save(volunteer);
         } else {
-            User user = userRepository.getReferenceById(currentUserId);
-            eventVolunteerRepository.save(EventVolunteer.enroll(event, user));
+            try {
+                User user = userRepository.getReferenceById(currentUserId);
+                eventVolunteerRepository.save(EventVolunteer.enroll(event, user));
+            } catch (DataIntegrityViolationException e) {
+                throw new DomainException("Você já está inscrito nesse evento");
+            }
         }
     }
 

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventVolunteerService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventVolunteerService.java
@@ -1,0 +1,113 @@
+package com.techfun.altrua.features.event.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.techfun.altrua.core.common.exceptions.DomainException;
+import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
+import com.techfun.altrua.core.common.util.SecurityUtils;
+import com.techfun.altrua.features.event.domain.enums.VolunteerStatusEnum;
+import com.techfun.altrua.features.event.domain.model.Event;
+import com.techfun.altrua.features.event.domain.model.EventVolunteer;
+import com.techfun.altrua.features.event.repository.EventRepository;
+import com.techfun.altrua.features.event.repository.EventVolunteerRepository;
+import com.techfun.altrua.features.user.domain.User;
+import com.techfun.altrua.features.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Serviço responsável por gerenciar o ciclo de vida das inscrições de
+ * voluntários em eventos.
+ * <p>
+ * Implementa regras de negócio críticas, como a validação de capacidade de
+ * eventos e o controle de estados de inscrição, utilizando bloqueios
+ * pessimistas para garantir a integridade dos dados em cenários de alta
+ * concorrência.
+ * </p>
+ */
+@Service
+@RequiredArgsConstructor
+public class EventVolunteerService {
+
+    private final EventRepository eventRepository;
+    private final EventVolunteerRepository eventVolunteerRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * Realiza a inscrição ou reativação de um voluntário em um evento específico.
+     * <p>
+     * O método valida se o usuário já possui inscrição ativa, se o evento pertence
+     * à ONG informada e se há vagas disponíveis sob lock de escrita. Caso uma
+     * inscrição prévia cancelada seja encontrada, ela é reativada; caso contrário,
+     * um novo registro é persistido.
+     * </p>
+     * 
+     * @param eventId Identificador do evento alvo.
+     * @param ongId   Identificador da ONG proprietária do evento.
+     * @throws DomainException           Se o usuário já estiver inscrito ou se o
+     *                                   limite de vagas for atingido.
+     * @throws ResourceNotFoundException Se o evento não for localizado no contexto
+     *                                   da ONG informada.
+     */
+    @Transactional
+    public void enroll(UUID eventId, UUID ongId) {
+        UUID currentUserId = SecurityUtils.getCurrentUserId();
+
+        Optional<EventVolunteer> existing = eventVolunteerRepository.findByEventIdAndUserId(eventId, currentUserId);
+
+        if (existing.isPresent() && existing.get().getStatus() == VolunteerStatusEnum.CONFIRMED) {
+            throw new DomainException("Você já está inscrito nesse evento");
+        }
+
+        Event event = eventRepository.findByIdAndOngIdForUpdate(eventId, ongId)
+                .orElseThrow(() -> new ResourceNotFoundException("Evento"));
+
+        long activeCount = eventVolunteerRepository.countActiveByEventId(eventId);
+        if (!event.acceptsNewVolunteers(activeCount)) {
+            throw new DomainException("O evento não aceita mais voluntários.");
+        }
+
+        if (existing.isPresent()) {
+            EventVolunteer volunteer = existing.get();
+            volunteer.reactivate();
+            eventVolunteerRepository.save(volunteer);
+        } else {
+            User user = userRepository.getReferenceById(currentUserId);
+            eventVolunteerRepository.save(EventVolunteer.enroll(event, user));
+        }
+    }
+
+    /**
+     * Cancela a inscrição do usuário autenticado em um evento determinado.
+     * <p>
+     * Utiliza bloqueio pessimista para recuperar a inscrição e validar o vínculo
+     * hierárquico com a ONG, garantindo que o cancelamento seja processado de forma
+     * isolada e segura. Se a inscrição já estiver cancelada, a operação é encerrada
+     * silenciosamente para manter a idempotência.
+     * </p>
+     * 
+     * @param eventId Identificador do evento.
+     * @param ongId   Identificador da ONG vinculada ao evento.
+     * @throws ResourceNotFoundException Se a inscrição ou o contexto ONG/Evento não
+     *                                   forem encontrados.
+     */
+    @Transactional
+    public void cancelEnrollment(UUID eventId, UUID ongId) {
+        UUID currentUserId = SecurityUtils.getCurrentUserId();
+
+        EventVolunteer volunteer = eventVolunteerRepository
+                .findByEventIdAndOngIdAndUserIdForUpdate(eventId, ongId, currentUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Inscrição"));
+
+        if (volunteer.getStatus() == VolunteerStatusEnum.CANCELLED) {
+            return;
+        }
+
+        volunteer.cancel();
+        eventVolunteerRepository.save(volunteer);
+    }
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventVolunteerService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventVolunteerService.java
@@ -66,7 +66,7 @@ public class EventVolunteerService {
         Event event = eventRepository.findByIdAndOngIdForUpdate(eventId, ongId)
                 .orElseThrow(() -> new ResourceNotFoundException("Evento"));
 
-        long activeCount = eventVolunteerRepository.countActiveByEventId(eventId);
+        long activeCount = eventVolunteerRepository.countByEventIdAndStatus(eventId, VolunteerStatusEnum.CONFIRMED);
         if (!event.acceptsNewVolunteers(activeCount)) {
             throw new DomainException("O evento não aceita mais voluntários.");
         }

--- a/backend/src/main/resources/db/migration/V20260416114310__create_event_volunteers_table.sql
+++ b/backend/src/main/resources/db/migration/V20260416114310__create_event_volunteers_table.sql
@@ -11,3 +11,6 @@ CREATE TABLE IF NOT EXISTS "event_volunteers" (
     FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_event_volunteers_confirmed_event_id ON event_volunteers(event_id)
+WHERE status = 'CONFIRMED';

--- a/backend/src/main/resources/db/migration/V20260416114310__create_event_volunteers_table.sql
+++ b/backend/src/main/resources/db/migration/V20260416114310__create_event_volunteers_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "event_volunteers" (
+    id UUID PRIMARY KEY,
+    event_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    confirmed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    cancelled_at TIMESTAMPTZ,
+
+    CONSTRAINT uk_event_user UNIQUE (event_id, user_id),
+
+    FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);


### PR DESCRIPTION
#### Alterações Realizadas
* **Domínio:** Implementação da entidade `EventVolunteer` e enum `VolunteerStatusEnum` para controle do ciclo de vida das inscrições.
* **Concorrência:** Adição de **Lock Pessimista** (`PESSIMISTIC_WRITE`) nos repositórios para evitar violação do limite de vagas em requisições paralelas.
* **Persistência:** Métodos para contagem de ativos e busca vinculada ao contexto da ONG, garantindo isolamento entre organizações.
* **API:** Endpoints `POST` (inscrição/reativação) e `DELETE` (cancelamento) mapeados sob o contexto da ONG e do Evento.

#### Regras de Negócio
1. **Inscrição:** Impede duplicidade de cadastros ativos e reativa registros previamente cancelados.
2. **Capacidade:** Validação de vagas realizada sob lock para assegurar a consistência do contador de voluntários.
3. **Segurança:** Operações de escrita exigem validação de `ongId` para prevenir manipulação de dados entre diferentes organizações.