### PR TITLE
Endpoint para listagem de eventos

### DIFF
--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventController.java
@@ -2,15 +2,20 @@ package com.techfun.altrua.features.event.api;
 
 import java.util.UUID;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.techfun.altrua.features.event.api.dto.EventFilterDTO;
 import com.techfun.altrua.features.event.api.dto.EventResponseDTO;
 import com.techfun.altrua.features.event.api.dto.RegisterEventRequestDTO;
 import com.techfun.altrua.features.event.domain.model.Event;
@@ -35,7 +40,6 @@ import lombok.RequiredArgsConstructor;
  */
 @Tag(name = "Eventos", description = "Gerenciamento de eventos vinculados a ONGs")
 @RestController
-@RequestMapping("/ongs/{ongId}/eventos")
 @RequiredArgsConstructor
 public class EventController {
 
@@ -61,7 +65,7 @@ public class EventController {
             @ApiResponse(responseCode = "404", description = "ONG não encontrada"),
             @ApiResponse(responseCode = "409", description = "Conflito: Slug do evento já existe")
     })
-    @PostMapping
+    @PostMapping("/ongs/{ongId}/eventos")
     @PreAuthorize("@securityService.isOngAdmin(#ongId)")
     public ResponseEntity<EventResponseDTO> register(
             @Parameter(description = "UUID da ONG proprietária") @PathVariable("ongId") UUID ongId,
@@ -90,7 +94,7 @@ public class EventController {
             @ApiResponse(responseCode = "403", description = "Usuário não tem permissão para gerenciar este evento"),
             @ApiResponse(responseCode = "404", description = "Evento não encontrado ou não pertence a esta ONG")
     })
-    @PostMapping("/{eventId}/encerrar")
+    @PostMapping("/ongs/{ongId}/eventos/{eventId}/encerrar")
     @PreAuthorize("@securityService.canManageEvent(#ongId, #eventId)")
     public ResponseEntity<Void> endEvent(
             @Parameter(description = "UUID da ONG proprietária") @PathVariable("ongId") UUID ongId,
@@ -99,4 +103,28 @@ public class EventController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Lista eventos de forma paginada com base em filtros dinâmicos.
+     * <p>
+     * Retorna apenas eventos que ainda não ocorreram (data de início no futuro).
+     * Os filtros de tag, status e disponibilidade de voluntariado são opcionais.
+     * </p>
+     *
+     * @param filter   DTO contendo os critérios de filtragem (tag, status,
+     *                 acceptsVolunteers).
+     * @param pageable Parâmetros de paginação e ordenação (padrão: 10 itens por
+     *                 página).
+     * @return {@link Page} contendo os eventos que atendem aos critérios.
+     */
+    @Operation(summary = "Listar eventos com filtros", description = "Recupera uma lista paginada de eventos futuros. Permite filtrar por tags, status e disponibilidade para voluntários.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Lista recuperada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Parâmetros de paginação ou filtro inválidos")
+    })
+    @GetMapping("/eventos")
+    public ResponseEntity<Page<EventResponseDTO>> list(
+            @ParameterObject EventFilterDTO filter,
+            @ParameterObject @PageableDefault(size = 10) Pageable pageable) {
+        return ResponseEntity.ok(eventService.listEvents(filter, pageable));
+    }
 }

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/EventSpecification.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/EventSpecification.java
@@ -1,0 +1,106 @@
+package com.techfun.altrua.features.event.api;
+
+import java.util.Locale;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.techfun.altrua.features.event.api.dto.EventFilterDTO;
+import com.techfun.altrua.features.event.domain.enums.EventStatusEnum;
+import com.techfun.altrua.features.event.domain.model.Event;
+import com.techfun.altrua.features.event.domain.model.Tag;
+
+import jakarta.persistence.criteria.Join;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Provedor de especificações para filtragem dinâmica de entidades
+ * {@link Event}.
+ * <p>
+ * Esta classe utiliza a JPA Criteria API para construir predicados baseados
+ * nos parâmetros fornecidos via {@link EventFilterDTO}.
+ * </p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class EventSpecification {
+
+    /**
+     * Constrói uma especificação composta para filtrar eventos futuros.
+     * 
+     * @param filter DTO contendo os critérios de busca (tag, status,
+     *               voluntários).
+     * @return {@link Specification} combinando o filtro de data atual com os
+     *         parâmetros opcionais.
+     */
+    public static Specification<Event> withFilter(EventFilterDTO filter) {
+        return Specification.where(nextEvents())
+                .and(withTag(filter.tag()))
+                .and(withStatus(filter.status()))
+                .and(withVolunteers(filter.acceptsVolunteers()));
+    }
+
+    /**
+     * Filtra eventos que possuam uma tag específica.
+     * <p>
+     * Realiza um {@code JOIN} com a tabela de tags e aplica a comparação
+     * em letras minúsculas. Ativa o modificador {@code DISTINCT} na query.
+     * </p>
+     * 
+     * @param tag Nome da tag para busca.
+     * @return Predicado de igualdade ou conjunção vazia se a tag for nula/vazia.
+     */
+    private static Specification<Event> withTag(String tag) {
+        return (root, query, criteriaBuilder) -> {
+            if (tag == null || tag.isBlank()) {
+                return criteriaBuilder.conjunction();
+            }
+
+            query.distinct(true);
+            Join<Event, Tag> tagJoin = root.join("tags");
+            return criteriaBuilder.equal(tagJoin.get("name"), tag.toLowerCase(Locale.ROOT));
+        };
+    }
+
+    /**
+     * Filtra eventos por seu estado atual.
+     * 
+     * @param status O {@link EventStatusEnum} desejado.
+     * @return Predicado de igualdade para o status.
+     */
+    private static Specification<Event> withStatus(EventStatusEnum status) {
+        return (root, query, criteriaBuilder) -> {
+            if (status == null) {
+                return criteriaBuilder.conjunction();
+            }
+
+            return criteriaBuilder.equal(root.get("status"), status);
+        };
+    }
+
+    /**
+     * Filtra eventos baseando-se na disponibilidade de vagas para voluntários.
+     * 
+     * @param acceptsVolunteers Booleano indicando a necessidade de voluntários.
+     * @return Predicado de igualdade para o campo {@code acceptsVolunteers}.
+     */
+    private static Specification<Event> withVolunteers(Boolean acceptsVolunteers) {
+        return (root, query, criteriaBuilder) -> {
+            if (acceptsVolunteers == null) {
+                return criteriaBuilder.conjunction();
+            }
+
+            return criteriaBuilder.equal(root.get("acceptsVolunteers"), acceptsVolunteers);
+        };
+    }
+
+    /**
+     * Restringe a consulta a eventos cuja data de início seja maior ou igual ao
+     * instante atual.
+     * 
+     * @return Predicado de comparação temporal com {@code CURRENT_TIMESTAMP}.
+     */
+    private static Specification<Event> nextEvents() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.greaterThanOrEqualTo(root.get("startsAt"),
+                criteriaBuilder.currentTimestamp());
+    }
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/api/dto/EventFilterDTO.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/api/dto/EventFilterDTO.java
@@ -1,0 +1,29 @@
+package com.techfun.altrua.features.event.api.dto;
+
+import com.techfun.altrua.features.event.domain.enums.EventStatusEnum;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO para transporte de filtros de busca de eventos.
+ * <p>
+ * Utilizado para realizar a filtragem dinâmica na listagem de eventos,
+ * permitindo buscas por categorias (tags), situação atual e disponibilidade de
+ * vagas.
+ * </p>
+ *
+ * @param tag               Nome da categoria/tag para filtrar eventos
+ *                          relacionados.
+ * @param status            Situação do evento (Ex: AGENDADO, FINALIZADO).
+ * @param acceptsVolunteers Filtro booleano para indicar se o evento busca novos
+ *                          voluntários.
+ */
+@Schema(description = "Critérios de filtragem para listagem de eventos")
+public record EventFilterDTO(
+
+        @Schema(description = "Nome da tag/categoria (case-insensitive)", example = "educacao") String tag,
+
+        @Schema(description = "Status atual do evento") EventStatusEnum status,
+
+        @Schema(description = "Se true, filtra eventos com vagas abertas para voluntariado", example = "true") Boolean acceptsVolunteers) {
+}

--- a/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/repository/EventRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,7 +22,7 @@ import jakarta.persistence.LockModeType;
  * no banco de dados utilizando Spring Data JPA.
  * </p>
  */
-public interface EventRepository extends JpaRepository<Event, UUID> {
+public interface EventRepository extends JpaRepository<Event, UUID>, JpaSpecificationExecutor<Event> {
 
     /**
      * Verifica se já existe um evento cadastrado com o slug fornecido.

--- a/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
+++ b/backend/src/main/java/com/techfun/altrua/features/event/service/EventService.java
@@ -5,6 +5,9 @@ import java.util.UUID;
 
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +16,9 @@ import com.techfun.altrua.core.common.exceptions.DuplicateResourceException;
 import com.techfun.altrua.core.common.exceptions.ResourceNotFoundException;
 import com.techfun.altrua.core.common.util.SecurityUtils;
 import com.techfun.altrua.core.common.util.SlugUtils;
+import com.techfun.altrua.features.event.api.EventSpecification;
+import com.techfun.altrua.features.event.api.dto.EventFilterDTO;
+import com.techfun.altrua.features.event.api.dto.EventResponseDTO;
 import com.techfun.altrua.features.event.api.dto.RegisterEventRequestDTO;
 import com.techfun.altrua.features.event.domain.model.Event;
 import com.techfun.altrua.features.event.domain.model.Tag;
@@ -38,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EventService {
 
     private final UserRepository userRepository;
@@ -110,5 +117,25 @@ public class EventService {
 
         event.finish();
         eventRepository.save(event);
+    }
+
+    /**
+     * Recupera uma página de eventos filtrados de acordo com os critérios
+     * fornecidos.
+     * <p>
+     * Este método aplica automaticamente uma restrição temporal, retornando apenas
+     * eventos cuja data de início seja igual ou posterior ao instante atual.
+     * </p>
+     *
+     * @param filter   Objeto contendo os critérios de filtragem (tags, status,
+     *                 voluntariado).
+     * @param pageable Configurações de paginação e ordenação.
+     * @return Uma {@link Page} de {@link EventResponseDTO} contendo os registros
+     *         encontrados
+     *         e metadados de paginação.
+     */
+    public Page<EventResponseDTO> listEvents(EventFilterDTO filter, Pageable pageable) {
+        Specification<Event> spec = EventSpecification.withFilter(filter);
+        return eventRepository.findAll(spec, pageable).map(EventResponseDTO::fromEntity);
     }
 }

--- a/backend/src/main/java/com/techfun/altrua/infra/security/SecurityConfig.java
+++ b/backend/src/main/java/com/techfun/altrua/infra/security/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/ongs").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/ongs", "/eventos").permitAll()
                         .requestMatchers(
                                 "/api-docs/**",
                                 "/docs/**",
@@ -127,8 +127,9 @@ public class SecurityConfig {
      * <li><b>Headers:</b> Todos permitidos ({@code *}).</li>
      * <li><b>Cache:</b> Configurações válidas por 1 hora (3600s).</li>
      * </ul>
+     * 
      * @return {@link CorsConfigurationSource} mapeado para todos os caminhos
-     * ({@code /**}).
+     *         ({@code /**}).
      */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {


### PR DESCRIPTION
Implementação do endpoint de listagem de eventos com suporte a filtragem dinâmica via `EventSpecification`. A lógica garante que apenas eventos futuros (`startsAt >= NOW`) sejam retornados.

### Endpoint
`GET /events`

### Exemplos de Requisição
- **Geral (Eventos Futuros):** `GET /events`
- **Por Tag:** `GET /events?tag=tecnologia`
- **Por Status:** `GET /events?status=PUBLISHED`
- **Apenas com Voluntários:** `GET /events?acceptsVolunteers=true`
- **Filtro Composto:** `GET /events?tag=saude&status=ONGOING&acceptsVolunteers=true`

### Detalhes Técnicos
* **Temporalidade:** Filtro `nextEvents()` mandatório (Hardcoded na Specification).
* **Tags:** Busca Case-Insensitive com `query.distinct(true)` para evitar duplicatas no Join.
* **Resiliência:** Parâmetros nulos ou vazios são ignorados através de `criteriaBuilder.conjunction()